### PR TITLE
Add possibility to skip Prometheus reload step in remove_prometheus_alert_rules.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ pip2 install -U virtualenv
 virtualenv ops
 source ops/bin/activate
 
-# install opswrapper v0.23 stable release
-pip2 install --upgrade https://github.com/adobe/ops-cli/releases/download/0.23/ops-0.23.tar.gz
+# install opswrapper v0.24 stable release
+pip2 install --upgrade https://github.com/adobe/ops-cli/releases/download/0.24/ops-0.24.tar.gz
 
 # Optionally, install terraform to be able to access terraform plugin
 # See https://www.terraform.io/intro/getting-started/install.html

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ _mydir = os.path.abspath(os.path.dirname(sys.argv[0]))
 _requires = [ r for r in open(os.path.sep.join((_mydir,'requirements.txt')), "r").read().split('\n') if len(r)>1 ]
 setup(
     name='ops',
-    version='0.23',
+    version='0.24',
     description='Ops simple wrapper',
     author='Adobe',
     author_email='noreply@adobe.com',

--- a/src/ops/data/ansible/tasks/remove_prometheus_alert_rules.yml
+++ b/src/ops/data/ansible/tasks/remove_prometheus_alert_rules.yml
@@ -1,6 +1,7 @@
 ## Remove specific rules from Prometheus
 # vars:
 # - delete_rule_files: a list of glob patterns to match the rule files to be deleted
+# - skip_reload: to skip the "Reloading Prometheus" step, set this variable to "yes"
 
 # Usage example:
 #
@@ -9,6 +10,7 @@
 #  include: {{ ops_tasks_dir }}/remove_prometheus_alert_rules.yml
 #  vars:
 #    delete_rule_files: '["some_rule*", "some_other_rule*", "specific_rule.rule"]'
+#    skip_reload: "yes"
 
 - name: "Verify delete_rule_files parameter is defined"
   assert:
@@ -45,4 +47,7 @@
   register: response
   retries: 5
   delay: 5
-  
+  vars:
+    skip_reload: "no"
+  when:
+    skip_reload != "yes"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/ops-cli/issues/8

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
