### PR TITLE
Support ops terraform force-unlock

### DIFF
--- a/src/ops/cli/terraform.py
+++ b/src/ops/cli/terraform.py
@@ -351,6 +351,18 @@ class TerraformRunner(object):
                     terraform_path=terraform_path,
                     vars=vars,
             )
+        elif args.subcommand is not None:
+            # Examples: 
+            #  - command = "state push errored.tfstate"
+            #  - command = "force-unlock <LOCK_ID>"
+            generate_module_templates = True
+            cmd = "cd {root_dir}/{terraform_path} && {terraform_init_command} " \
+                  "terraform {command}".format(
+                    command=args.subcommand,
+                    root_dir=self.root_dir,
+                    terraform_init_command=terraform_init_command,
+                    terraform_path=terraform_path,
+            )
         else:
             display('Terraform subcommand \'%s\' not found' % args.subcommand, color='red')
             return


### PR DESCRIPTION
## Description

Useful for cases where the tf states are stored remotely (ie. in an S3 bucket) with DynamoDB locking. If something happens (eg. credentials expire, terraform crashes), it would be useful to have a way to remove the lock that was acquired. Currently, this can only be done manually, by going to DynamoDB and removing the entry (the lock). However, terraform has a command to remove it. 

This PR makes it possible to run:
```sh
ops clusters/mycluster.yaml terraform force-unlock c462b73c-9df7-5901-d84f-6c384d854fce

ops clusters/mycluster.yaml terraform state push errored.tfstate
```

## Related Issue

Fixes #10

<img width="647" alt="screenshot 2019-02-08 19 05 34" src="https://user-images.githubusercontent.com/952836/52493582-88d17400-2bd4-11e9-9701-8b591784bb84.png">
