### PR TITLE
[FIX] Can't install ops-cli in dev mode on a fresh python virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ ops clusters/my-kubernetes-cluster.yaml terraform --path-name aws-eks plan
 git clone https://github.com/adobe/ops-cli.git
 cd ops
 # Install openssl
-brew install openssl
+brew install openssl libyaml
 env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" python setup.py develop
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 simpledi>=0.2
 awscli==1.16.97
 ansible==2.3.1.0
-boto3==1.9.91
+s3transfer==0.1.13
+boto3==1.9.87
 boto==2.49.0
+botocore==1.12.87
+PyYAML==3.13
 azure-common==1.1.4
 azure==2.0.0rc5
 msrestazure==0.4.6


### PR DESCRIPTION
This is the fix for https://github.com/adobe/ops-cli/issues/17