### PR TITLE
Security update + fix for ops config

### DIFF
--- a/src/ops/cli/config.py
+++ b/src/ops/cli/config.py
@@ -107,7 +107,7 @@ class JinjaConfigGenerator(object):
 
         rendered = self.template.render(self.cluster_config_path, variables)
 
-        return yaml.load(rendered)
+        return yaml.safe_load(rendered)
 
 class ClusterConfigGenerator(object):
     def __init__(self, console_args, cluster_config_path, template):

--- a/src/ops/cli/terraform.py
+++ b/src/ops/cli/terraform.py
@@ -261,6 +261,8 @@ class TerraformRunner(object):
 
         elif args.subcommand == 'destroy':
             generate_module_templates = True
+            remove_local_cache = ''
+
             if self.ops_config['terraform.remove_local_cache']:
                 remove_local_cache = 'rm -rf .terraform && '
             cmd = "cd {root_dir}/{terraform_path} && " \

--- a/src/ops/inventory/plugin/skms.py
+++ b/src/ops/inventory/plugin/skms.py
@@ -41,7 +41,7 @@ def skms(args):
     credentials_file = "%s/.skms/credentials.yaml" % os.path.expanduser('~')
     if os.path.isfile(credentials_file):
         file_stream = open(credentials_file, "r")
-        docs = yaml.load_all(file_stream)
+        docs = yaml.safe_load_all(file_stream)
         for doc in docs:
             args['skms']['username'] = doc['username']
             args['skms']['password'] = doc['password']

--- a/src/ops/opsconfig.py
+++ b/src/ops/opsconfig.py
@@ -102,7 +102,7 @@ class OpsConfig(object):
             if os.path.isfile(config_path):
                 logger.info("parsing %s", config_path)
                 with open(config_path) as f:
-                    config = yaml.load(f.read())
+                    config = yaml.safe_load(f.read())
                     if isinstance(config, dict):
                         parsed_files.append(config_path)
                         self.config.update(config)


### PR DESCRIPTION
This PR contains a security fix which involves the usage of `yaml.safe_load()` function instead of `yaml.load()` (CVE-2017-18342 )

The second commit initialise `remove_local_cache` which is not set in case ops config file is not found.