### PR TITLE
Allow ssh'ing into custom hostnames/IPs not in inventory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,27 @@
 language: python
+env:
+  - BOTO_CONFIG=/dev/null
 python:
 - '2.7'
 install:
-- pip install -r requirements.txt
+- pip install pipenv
 script:
+# freeze deps
+- |
+  rm -rf Pipfile* deps &&
+  pipenv lock --clear --two --requirements 1>deps &&
+  grep '==' deps | sed "s/;\\sextra.*//" > requirements.txt
 # test
-- export HOME=`pwd`/tmptests && rm -rf $HOME && export PATH=$HOME/.local/bin:$PATH && nosetests --with-xunit tests/unit
+- |
+  pip install --no-cache-dir -r requirements.txt &&
+  nosetests --with-xunit tests/unit
 # build artifact
-- export HOME=`pwd`/build && rm -rf $HOME && python setup.py sdist bdist_wheel
+- python setup.py sdist bdist_wheel
 - ls -l dist/
+# dry run
+- |
+  pip install --no-cache-dir dist/ops*.tar.gz &&
+  ops --verbose -h
 
 deploy:
   provider: releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN helm init --client-only
 RUN pip2 install -U virtualenv
 RUN virtualenv ops
 RUN source ops/bin/activate
-RUN pip2 install --upgrade https://github.com/adobe/ops-cli/releases/download/0.28/ops-0.28.tar.gz
+RUN pip2 install --upgrade https://github.com/adobe/ops-cli/releases/download/0.29/ops-0.29.tar.gz

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ pip2 install -U virtualenv
 virtualenv ops
 source ops/bin/activate
 
-# install opswrapper v0.28 stable release
-pip2 install --upgrade https://github.com/adobe/ops-cli/releases/download/0.28/ops-0.28.tar.gz
+# install opswrapper v0.29 stable release
+pip2 install --upgrade https://github.com/adobe/ops-cli/releases/download/0.29/ops-0.29.tar.gz
 
 # Optionally, install terraform to be able to access terraform plugin
 # See https://www.terraform.io/intro/getting-started/install.html
@@ -99,7 +99,7 @@ You can try out `ops-cli`, by using docker. The docker image has all required pr
 
 To start out a container, running the latest `ops-cli` docker image run:
 ```sh
-docker run -it costimuraru/ops-cli:0.28 bash
+docker run -it costimuraru/ops-cli:0.29 bash
 ```
 
 After the container has started, you can start using `ops-cli`:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ PyYAML==3.13
 azure-common==1.1.4
 azure==2.0.0rc5
 msrestazure==0.4.6
-jinja2<2.9
+Jinja2==2.10.1
 hashmerge
 python-consul
 hvac>=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ _mydir = os.path.abspath(os.path.dirname(sys.argv[0]))
 _requires = [ r for r in open(os.path.sep.join((_mydir,'requirements.txt')), "r").read().split('\n') if len(r)>1 ]
 setup(
     name='ops',
-    version='0.28',
+    version='0.29',
     description='Ops simple wrapper',
     author='Adobe',
     author_email='noreply@adobe.com',

--- a/src/ops/inventory/ec2inventory.py
+++ b/src/ops/inventory/ec2inventory.py
@@ -214,7 +214,10 @@ class Ec2Inventory(object):
                     group_names.append(group.name)
                 instance_vars["ec2_security_group_ids"] = ','.join(group_ids)
                 instance_vars["ec2_security_group_names"] = ','.join(group_names)
-
+        # add non ec2 prefix private ip address that are being used in cross provider command
+        # e.g ssh, sync
+        instance_vars['private_ip'] = instance_vars.get('ec2_private_ip_address', '')
+        instance_vars['private_ip_address'] = instance_vars.get('ec2_private_ip_address', '')
         return instance_vars
 
     def get_host_info(self):

--- a/src/ops/inventory/ec2inventory.py
+++ b/src/ops/inventory/ec2inventory.py
@@ -242,12 +242,16 @@ class Ec2Inventory(object):
     def push(self, my_dict, key, element):
         ''' Push an element onto an array that may not have been defined in
         the dict '''
+        if key == element:
+            return
         group_info = my_dict.setdefault(key, [])
         if isinstance(group_info, dict):
             host_list = group_info.setdefault('hosts', [])
-            host_list.append(element)
+            if element not in host_list:
+                host_list.append(element)
         else:
-            group_info.append(element)
+            if element not in group_info:
+                group_info.append(element)
 
     def push_group(self, my_dict, key, element):
         ''' Push a group as a child of another group. '''


### PR DESCRIPTION
Extend ssh and sync commands to allow custom hostnames/IPs

## Description

When using `ssh` and `sync` command with hosts/ips not in inventory, ops should fallback to 
provided hostname/ip when device is not found in inventory
E.g:
`ops cluster.yaml ssh 10.0.0.1` 
ssh into `bastion--10.0.0.1` even when the ip is not part of the inventory

`ops cluster.yaml sync file.txt 10.0.0.1:/tmp`
rsync into `bastion--10.0.0.1:/tmp`

## Motivation and Context

This is needed in environments where the hosts are not part of the inventory
but reachable via bastion

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Using local environment

## Screenshots (if appropriate):
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.