### PR TITLE
removed -module-depth to support terraform 0.12

### DIFF
--- a/src/ops/cli/terraform.py
+++ b/src/ops/cli/terraform.py
@@ -219,7 +219,7 @@ class TerraformRunner(object):
                   "{terraform_init_command}" \
                   "{terraform_refresh_command}" \
                   "terraform plan " \
-                  "-out={plan_file} -refresh=false -module-depth=1 -input=false {vars} {state_argument}".format(
+                  "-out={plan_file} -refresh=false -input=false {vars} {state_argument}".format(
                     root_dir=self.root_dir,
                     terraform_path=terraform_path,
                     terraform_init_command=terraform_init_command,
@@ -269,7 +269,7 @@ class TerraformRunner(object):
                   "{remove_local_cache}" \
                   "{terraform_init_command}" \
                   "terraform plan -destroy " \
-                  "-refresh=true -module-depth=1 {vars} {state_argument} && " \
+                  "-refresh=true {vars} {state_argument} && " \
                   "terraform destroy {vars} {state_argument} -refresh=true".format(
                     root_dir=self.root_dir,
                     terraform_path=terraform_path,
@@ -315,7 +315,7 @@ class TerraformRunner(object):
                 state=state_file
 
             cmd = "cd {root_dir}/{terraform_path} && " \
-                  "terraform show -module-depth=-1 {state}".format(
+                  "terraform show {state}".format(
                     root_dir=self.root_dir,
                     terraform_path=terraform_path,
                     state=state


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

-module-depth flag has been removed from terraform generated command as this is not supported anymore by latest version of terraform (0.12)

## Related Issue
Related issue - https://github.com/adobe/ops-cli/issues/31 

## Motivation and Context

It is required in order to be able to execute code with terraform 0.12 

## How Has This Been Tested?

Tested by running ops terraform plan & apply with terraform 0.11 and 0.12

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
