### PR TITLE
Enchance Vault utils

### DIFF
--- a/src/ops/ansible/filter_plugins/commonfilters.py
+++ b/src/ops/ansible/filter_plugins/commonfilters.py
@@ -64,6 +64,20 @@ def flatten_tree(d, parent_key='', sep='/'):
             items.append((new_key, v))
     return dict(items)
 
+def check_vault(
+        secret_path, key='value', vault_user=None, vault_url=None,
+        token=None, namespace=None, mount_point=None, auto_prompt=True):
+
+    from ops.simplevault import SimpleVault
+    sv = SimpleVault(
+        vault_user=vault_user, vault_addr=vault_url, vault_token=token, 
+        namespace=namespace, mount_point=mount_point, auto_prompt=auto_prompt)
+    check_status = sv.check(secret_path, key)
+    # we want to return these string values because this is what Jinja2 understands
+    if check_status:
+        return "true"
+    return "false"
+
 def read_vault(
         secret_path, key='value', fetch_all=False, vault_user=None, vault_url=None,
         token=None, namespace=None, mount_point=None, auto_prompt=True):
@@ -136,9 +150,9 @@ class FilterModule(object):
             'read_file': read_file,
             'read_vault': read_vault,
             'read_yaml': read_yaml,
-            'read_vault': read_vault,
             'write_vault': write_vault,
             'managed_vault_secret': managed_vault_secret,
             'read_ssm': read_ssm,
-            'escape_json': escape_json
+            'escape_json': escape_json,
+            'check_vault': check_vault
         }


### PR DESCRIPTION
Enhance Vault modules and add support for enforcing a minimum ops version in Terraform clusters.

Addresses issue https://github.com/adobe/ops-cli/issues/55 

## Description
1. Enhance Vault module, now it will not muffle Exceptions and exposed another function called check_vault() that will return a Jinja2 friendly boolean ("true" or "false")
2. Added support for enforcing a minimum ops version in Terraform clusters ("ops_min_version")

## Motivation and Context

1. Aims to solve scenarios where reading a non-existent Vault secret always returned "None" and never threw an exception.
2. Aims to make it easier to enforce a minimum version of ops across larger teams.

## How Has This Been Tested?

Built the ops Docker container locally from sources, ran Terraform plan and apply on our clusters.
Also tested with older versions of ops which now fail because another PR will introduce a new function in the TF modules that will only exist in the newer ops.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
