### PR TITLE
Upgrade himl pip dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ hvac==0.9.3
 passgen
 inflection==0.3.1
 kubernetes==9.0.0
-himl==0.1.15
+himl==0.1.18


### PR DESCRIPTION
Latest `himl` version fixes warning:

```
site-packages/himl/config_generator.py:183: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```
