### PR TITLE
Add bastion tag parameter to azure plugin

### DIFF
--- a/src/ops/inventory/plugin/azr.py
+++ b/src/ops/inventory/plugin/azr.py
@@ -45,7 +45,8 @@ class OpsAzureInventory(AzureInventory):
                 'resource_groups': None,
                 'tags': None,
                 'locations': None,
-                'no_powerstate': False
+                'no_powerstate': False,
+                'bastion_tag': 'Adobe:Class'
                 }
         if not HAS_AZURE:
             raise HAS_AZURE_EXC
@@ -95,7 +96,7 @@ class OpsAzureInventory(AzureInventory):
         bastions = {}
         for host, hostvars in iteritems(self._inventory['_meta']['hostvars']):
             if ('role' in hostvars['tags'] and hostvars['tags']['role'] == 'bastion') or \
-              ('Adobe:Class' in hostvars['tags'] and hostvars['tags']['Adobe:Class'] == 'bastion'):
+              (self._args.bastion_tag in hostvars['tags'] and hostvars['tags'][self._args.bastion_tag] == 'bastion'):
                 if hostvars['public_ip'] is not None:
                     bastion_ip = hostvars['public_ip']
                     location = hostvars['location']
@@ -107,7 +108,7 @@ class OpsAzureInventory(AzureInventory):
         if bastions:
             for host, hostvars in iteritems(self._inventory['_meta']['hostvars']):
                 if ('role' in hostvars['tags'] and hostvars['tags']['role'] == 'bastion') or \
-                  ('Adobe:Class' in hostvars['tags'] and hostvars['tags']['Adobe:Class'] == 'bastion'):
+                  (self._args.bastion_tag in hostvars['tags'] and hostvars['tags'][self._args.bastion_tag] == 'bastion'):
                     pass
                 else:
                     private_ip = hostvars['private_ip']


### PR DESCRIPTION
# This allows customizing this tag in the cluster configuration.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a parameter for the bastion tag in the azure plugin.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#14 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Allow customization in the cluster config.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I haven't run the tests for I'm not familiar with the test suite. How can I run the tests?
Should I create new tests for this feature?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
