### PR TITLE
Don't run terraform operations in case the AWS credentials are about to expire

### DIFF
--- a/src/ops/cli/__init__.py
+++ b/src/ops/cli/__init__.py
@@ -18,7 +18,7 @@ def get_output(command, trim=True):
     if trim:
         out = out.strip()
 
-    return out
+    return out.decode("utf-8")
 
 
 def display(msg, **kwargs):

--- a/src/ops/cli/aws.py
+++ b/src/ops/cli/aws.py
@@ -26,7 +26,7 @@ def expiry_dttm(profile):
     return get_output('aws configure get expiry_dttm --profile %s' % profile)
 
 
-def expiry_dttm_in_minutes(profile):
+def minutes_until_expire(profile):
     diff = (datetime.strptime(expiry_dttm(profile), "%Y-%m-%dT%H:%M:%S%z") - datetime.now(timezone.utc)).total_seconds()
 
     return int(diff / 60)

--- a/src/ops/cli/aws.py
+++ b/src/ops/cli/aws.py
@@ -9,6 +9,7 @@
 # governing permissions and limitations under the License.
 
 from . import get_output
+from datetime import datetime, timezone
 
 
 def acess_key(profile):
@@ -19,3 +20,13 @@ def acess_key(profile):
 def secret_key(profile):
     return get_output(
         'aws configure get aws_secret_access_key --profile %s' % profile)
+
+
+def expiry_dttm(profile):
+    return get_output('aws configure get expiry_dttm --profile %s' % profile)
+
+
+def expiry_dttm_in_minutes(profile):
+    diff = (datetime.strptime(expiry_dttm(profile), "%Y-%m-%dT%H:%M:%S%z") - datetime.now(timezone.utc)).total_seconds()
+
+    return int(diff / 60)

--- a/src/ops/terraform/terraform_cmd_generator.py
+++ b/src/ops/terraform/terraform_cmd_generator.py
@@ -16,6 +16,10 @@ import logging
 from jinja2 import FileSystemLoader
 from subprocess import Popen, PIPE
 from ops.cli import err, display
+from ops.cli.aws import expiry_dttm_in_minutes
+
+# The minimum time (in minutes) allowed for the credentials to be valid for terraform to run.
+MINIMUM_CREDENTIALS_EXPIRE_TIME = 5
 
 
 class TerraformCommandGenerator(object):
@@ -28,6 +32,11 @@ class TerraformCommandGenerator(object):
         self.template = template
 
     def generate(self, args):
+        if 'AWS_PROFILE' in os.environ:
+            if expiry_dttm_in_minutes(os.environ['AWS_PROFILE']) < MINIMUM_CREDENTIALS_EXPIRE_TIME:
+                raise Exception("The AWS credentials are about to expire (< %s mins). "
+                                "To avoid potential errors in case the credentials expire during a "
+                                "terrafrom operation, you should renew them before continuing." % MINIMUM_CREDENTIALS_EXPIRE_TIME)
 
         self.selected_terraform_path = args.path_name
         self.set_current_working_dir()


### PR DESCRIPTION
## Description

The cli tool will check if the AWS credentials are going to expire in the next 5 minutes and stop the execution.

## Motivation and Context

https://github.com/terraform-providers/terraform-provider-aws/issues/4502

## How Has This Been Tested?

Using AWS credentials valid for 1h and setting the `AWS_PROFILE` env variable.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
