### PR TITLE
Add concurrency option for helmfile commands

### DIFF
--- a/src/ops/cli/config_generator.py
+++ b/src/ops/cli/config_generator.py
@@ -12,6 +12,7 @@ import logging
 from himl.main import ConfigRunner
 from ops.cli.parser import SubParserConfig
 
+logger = logging.getLogger(__name__)
 
 class ConfigGeneratorParserConfig(SubParserConfig):
     def get_name(self):
@@ -35,7 +36,8 @@ class ConfigGeneratorRunner(object):
     def __init__(self, cluster_config_path):
         self.cluster_config_path = cluster_config_path
 
-    def run(self, args):
+    def run(self, args, extra_args):
+        logger.info("Found extra_args %s", extra_args)
         logging.basicConfig(level=logging.INFO)
         args.path = self.cluster_config_path
         if args.output_file is None:

--- a/src/ops/cli/helmfile.py
+++ b/src/ops/cli/helmfile.py
@@ -52,6 +52,8 @@ class HelmfileParserConfig(SubParserConfig):
             ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile sync
             # Run helmfile sync for a single chart
             ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile sync -- --selector chart=nginx-controller
+            # Run helmfile sync with concurrency flag
+            ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile --concurrency=1 sync -- --selector chart=nginx-controller
         '''
 
 
@@ -151,5 +153,10 @@ class HelmfileRunner(CompositionConfigGenerator, object):
                                                      print_data=True)
 
     def get_helmfile_command(self, args):
-        cmd = ' '.join(args.extra_args + [args.subcommand])
-        return "cd {} && helmfile {}".format(args.helmfile_path, cmd)
+        extra_args = ' '.join(args.extra_args)
+        helm_concurent_proc = '--concurrency={}'.format(args.concurrency) if args.concurrency else ''
+        return "cd {helmfile_path} && helmfile {extra_args} {subcommand} {concurrency}".format(
+            helmfile_path=args.helmfile_path,
+            extra_args=extra_args,
+            subcommand=args.subcommand,
+            concurrency=helm_concurent_proc)

--- a/src/ops/cli/helmfile.py
+++ b/src/ops/cli/helmfile.py
@@ -30,14 +30,10 @@ class HelmfileParserConfig(SubParserConfig):
 
     def configure(self, parser):
         parser.add_argument(
-            'subcommand',
-            help='plan | sync | apply | template',
-            type=str)
-        parser.add_argument(
-            'extra_args',
+            'helmfile_args',
             type=str,
             nargs='*',
-            help='Extra args')
+            help='Full subcommand of helmfile including params')
         parser.add_argument(
             '--helmfile-path',
             type=str,
@@ -51,9 +47,9 @@ class HelmfileParserConfig(SubParserConfig):
             # Run helmfile sync
             ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile sync
             # Run helmfile sync for a single chart
-            ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile sync -- --selector chart=nginx-controller
+            ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile -- --selector chart=nginx-controller sync
             # Run helmfile sync with concurrency flag
-            ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile --concurrency=1 sync -- --selector chart=nginx-controller
+            ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile -- --selector chart=nginx-controller sync --concurrency=1
         '''
 
 
@@ -153,10 +149,7 @@ class HelmfileRunner(CompositionConfigGenerator, object):
                                                      print_data=True)
 
     def get_helmfile_command(self, args):
-        extra_args = ' '.join(args.extra_args)
-        helm_concurent_proc = '--concurrency={}'.format(args.concurrency) if args.concurrency else ''
-        return "cd {helmfile_path} && helmfile {extra_args} {subcommand} {concurrency}".format(
+        helmfile_args = ' '.join(args.helmfile_args)
+        return "cd {helmfile_path} && helmfile {helmfile_args}".format(
             helmfile_path=args.helmfile_path,
-            extra_args=extra_args,
-            subcommand=args.subcommand,
-            concurrency=helm_concurent_proc)
+            helmfile_args=helmfile_args)

--- a/src/ops/cli/helmfile.py
+++ b/src/ops/cli/helmfile.py
@@ -30,11 +30,6 @@ class HelmfileParserConfig(SubParserConfig):
 
     def configure(self, parser):
         parser.add_argument(
-            'helmfile_args',
-            type=str,
-            nargs='*',
-            help='Full subcommand of helmfile including params')
-        parser.add_argument(
             '--helmfile-path',
             type=str,
             default=None,
@@ -47,9 +42,9 @@ class HelmfileParserConfig(SubParserConfig):
             # Run helmfile sync
             ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile sync
             # Run helmfile sync for a single chart
-            ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile -- --selector chart=nginx-controller sync
+            ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile --selector chart=nginx-controller sync
             # Run helmfile sync with concurrency flag
-            ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile -- --selector chart=nginx-controller sync --concurrency=1
+            ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile --selector chart=nginx-controller sync --concurrency=1
         '''
 
 
@@ -61,7 +56,7 @@ class HelmfileRunner(CompositionConfigGenerator, object):
         self.cluster_config_path = cluster_config_path
         self.execute = execute
 
-    def run(self, args):
+    def run(self, args, extra_args):
         config_path_prefix = os.path.join(self.cluster_config_path, '')
         default_helmfiles = '../ee-k8s-infra/compositions/helmfiles'
         args.helmfile_path = default_helmfiles if args.helmfile_path is None else os.path.join(
@@ -77,7 +72,7 @@ class HelmfileRunner(CompositionConfigGenerator, object):
         data = self.generate_helmfile_config(conf_path, args)
         self.setup_kube_config(data)
 
-        command = self.get_helmfile_command(args)
+        command = self.get_helmfile_command(args, extra_args)
         return dict(command=command)
 
     def setup_kube_config(self, data):
@@ -148,8 +143,8 @@ class HelmfileRunner(CompositionConfigGenerator, object):
                                                      output_file=output_file,
                                                      print_data=True)
 
-    def get_helmfile_command(self, args):
-        helmfile_args = ' '.join(args.helmfile_args)
+    def get_helmfile_command(self, args, extra_args):
+        helmfile_args = ' '.join(extra_args)
         return "cd {helmfile_path} && helmfile {helmfile_args}".format(
             helmfile_path=args.helmfile_path,
             helmfile_args=helmfile_args)

--- a/src/ops/cli/inventory.py
+++ b/src/ops/cli/inventory.py
@@ -9,12 +9,14 @@
 # governing permissions and limitations under the License.
 
 import yaml
+import logging
 
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.utils.color import stringc
 from . import display
 from .parser import configure_common_arguments, SubParserConfig
 
+logger = logging.getLogger(__name__)
 
 class InventoryParserConfig(SubParserConfig):
     def get_name(self):
@@ -45,7 +47,8 @@ class InventoryRunner(object):
         self.ansible_inventory = ansible_inventory
         self.cluster_name = cluster_name
 
-    def run(self, args):
+    def run(self, args, extra_args):
+        logger.info("Found extra_args %s", extra_args)
         for host in self.get_inventory_hosts(args):
             group_names = [group.name for group in host.get_groups()]
             group_names = sorted(group_names)

--- a/src/ops/cli/packer.py
+++ b/src/ops/cli/packer.py
@@ -8,9 +8,11 @@
 # OF ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import logging
 from ops.cli.parser import SubParserConfig
 from . import aws
 
+logger = logging.getLogger(__name__)
 
 class PackerParserConfig(SubParserConfig):
     def get_name(self):
@@ -39,7 +41,8 @@ class PackerRunner(object):
         self.cluster_config = cluster_config
         self.root_dir = root_dir
 
-    def run(self, args):
+    def run(self, args, extra_args):
+        logger.info("Found extra_args %s", extra_args)
         config_all = self.cluster_config.all()
 
         packer_variables = config_all['packer']['variables']

--- a/src/ops/cli/parser.py
+++ b/src/ops/cli/parser.py
@@ -75,6 +75,10 @@ class RootParser(object):
         RootParser._check_args_for_unicode(args)
         return self._get_parser().parse_args(args)
 
+    def parse_known_args(self, args=None):
+        RootParser._check_args_for_unicode(args)
+        return self._get_parser().parse_known_args(args)
+
 
 class SubParserConfig(object):
     def get_name(self):

--- a/src/ops/cli/playbook.py
+++ b/src/ops/cli/playbook.py
@@ -11,7 +11,9 @@
 from .parser import SubParserConfig
 from .parser import configure_common_ansible_args, configure_common_arguments
 import getpass
+import logging
 
+logger = logging.getLogger(__name__)
 
 class PlaybookParserConfig(SubParserConfig):
     def get_name(self):
@@ -66,7 +68,8 @@ class PlaybookRunner(object):
         self.cluster_config_path = cluster_config_path
         self.cluster_config = cluster_config
 
-    def run(self, args):
+    def run(self, args, extra_args):
+        logger.info("Found extra_args %s", extra_args)
         inventory_path, ssh_config_path = self.inventory_generator.generate()
 
         ssh_config = "ANSIBLE_SSH_ARGS='-F %s'" % ssh_config_path

--- a/src/ops/cli/run.py
+++ b/src/ops/cli/run.py
@@ -8,8 +8,10 @@
 # OF ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import logging
 from .parser import configure_common_ansible_args, SubParserConfig
 
+logger = logging.getLogger(__name__)
 
 class CommandParserConfig(SubParserConfig):
     def get_epilog(self):
@@ -61,7 +63,8 @@ class CommandRunner(object):
         self.cluster_config_path = cluster_config_path
         self.cluster_config = cluster_config
 
-    def run(self, args):
+    def run(self, args, extra_args):
+        logger.info("Found extra_args %s", extra_args)
         inventory_path, ssh_config_path = self.inventory_generator.generate()
         limit = args.host_pattern
 

--- a/src/ops/cli/ssh.py
+++ b/src/ops/cli/ssh.py
@@ -20,7 +20,9 @@ import sys
 import getpass
 import re
 import os
+import logging
 
+logger = logging.getLogger(__name__)
 IP_HOST_REG_EX = re.compile(r'^((\d+)\.(\d+)\.(\d+)\.(\d+):)?(\d+)$')
 
 
@@ -126,7 +128,8 @@ class SshRunner(object):
         self.cluster_config = cluster_config
         self.ansible_inventory = ansible_inventory
 
-    def run(self, args):
+    def run(self, args, extra_args):
+        logger.info("Found extra_args %s", extra_args)
         if args.keygen:
             if self.cluster_config.has_ssh_keys:
                 err('Cluster already has ssh keys, refusing to overwrite')

--- a/src/ops/cli/sync.py
+++ b/src/ops/cli/sync.py
@@ -8,12 +8,14 @@
 # OF ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import logging
 import getpass
 import subprocess
 
 from .parser import SubParserConfig
 from . import *
 
+logger = logging.getLogger(__name__)
 
 class SyncParserConfig(SubParserConfig):
     def configure(self, parser):
@@ -64,7 +66,8 @@ class SyncRunner(object):
         self.cluster_config = cluster_config
         self.ops_config = ops_config
 
-    def run(self, args):
+    def run(self, args, extra_args):
+        logger.info("Found extra_args %s", extra_args)
         inventory_path, ssh_config_path = self.inventory_generator.generate()
         src = PathExpr(args.src)
         dest = PathExpr(args.dest)

--- a/src/ops/cli/terraform.py
+++ b/src/ops/cli/terraform.py
@@ -20,7 +20,6 @@ import pkg_resources
 
 logger = logging.getLogger(__name__)
 
-
 class TerraformParserConfig(SubParserConfig):
     def get_name(self):
         return 'terraform'
@@ -171,7 +170,8 @@ class TerraformRunner(object):
                     self.cluster_config.conf["terraform"]["ops_min_version"])
                 validate_ops_version(ops_min_version)
 
-    def run(self, args):
+    def run(self, args, extra_args):
+        logger.info("Found extra_args %s", extra_args)
         self.check_ops_version()
         terraform_config_path = os.environ.get(
                                                 "TF_CLI_CONFIG_FILE",

--- a/src/ops/main.py
+++ b/src/ops/main.py
@@ -113,13 +113,14 @@ class AppContainer(Container):
         self.inventory_plugins = inventory_plugins
 
     def configure(self):
-        args = self.root_parser.parse_args(self.argv)
+        args, extra_args = self.root_parser.parse_known_args(self.argv)
         configure_logging(args)
 
-        logger.debug('cli args: %s', args)
+        logger.debug('cli args: %s, extra_args: %s', args, extra_args)
 
         # Bind some very useful dependencies
         self.console_args = cache(instance(args))
+        self.console_extra_args = cache(instance(extra_args))
         self.command = lambda c: self.console_args.command
         self.cluster_config_path = cache(
             lambda c: get_cluster_config_path(
@@ -144,7 +145,7 @@ class AppContainer(Container):
         command_name = '%s_runner' % self.console_args.command
         runner_instance = self.get_instance(command_name)
 
-        return runner_instance.run(self.console_args)
+        return runner_instance.run(self.console_args, self.console_extra_args)
 
 
 def run(args=None):


### PR DESCRIPTION
## Description
Add support for helmfile execution with `--concurrency` option

## Related Issue
Fixes #80 

## Motivation and Context
Running multiple helmfile release tillerless can cause concurrency issues.
https://github.com/roboll/helmfile/issues/690 

Usage: `ops data/env=dev/region=va6/project=ee/cluster=experiments/composition=helmfiles helmfile --concurrency=1 sync -- --selector chart=nginx-controller`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
