### PR TITLE
Replace expensive string concatenation and split with rpartition()

### DIFF
--- a/src/ops/opsconfig.py
+++ b/src/ops/opsconfig.py
@@ -19,16 +19,14 @@ logger = logging.getLogger(__name__)
 def file_tree(config_path, search_fname):
     """ From the current dir returns a list with all the files in the file tree to the root dir """
 
-    parts = os.path.realpath(config_path).split('/')
+    parts = os.path.realpath(config_path)
 
     file_stack = []
 
     while parts:
-        dir_name = '/'.join(parts)
-        fname = dir_name + '/' + search_fname
+        fname = '/'.join((parts, search_fname))
         file_stack.append(fname)
-
-        parts = parts[:-1]
+        parts = parts.rpartition('/')[0]
 
     return file_stack
 
@@ -129,7 +127,7 @@ class OpsConfig(object):
 
     @property
     def ansible_config_path(self):
-        value = self.config.get('ansible.config_path', None)
+        value = self.config.get('ansible.config_path')
         if value:
             return value
         else:


### PR DESCRIPTION
## Description

`parts = os.path.realpath(config_path).split('/')` and `dir_name = '/'.join(parts)` are two expensive operations that undo each other's work. `rpartition()` is the better solution that avoids the use of the two aforementioned operations.

## Related Issue

#73 (Best practices)

## Motivation and Context

Code should be as fast as possible especially if there is zero cost in readability and maintainability.

## How Has This Been Tested?

I used tests attached in tests\ directory.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
