### PR TITLE
Removed default context fallback

### DIFF
--- a/src/ops/cli/helmfile.py
+++ b/src/ops/cli/helmfile.py
@@ -81,7 +81,7 @@ class HelmfileRunner(CompositionConfigGenerator, object):
         return dict(command=command)
 
     def setup_kube_config(self, data):
-        if  data['helm']['global']['clusterType'] == 'eks':
+        if data['helm']['global']['clusterType'] == 'eks':
             cluster_name = data['helm']['global']['fqdn']
             aws_profile = data['helm']['global']['aws']['name']
             region = data['helm']['global']['region']['location']

--- a/src/ops/cli/helmfile.py
+++ b/src/ops/cli/helmfile.py
@@ -11,10 +11,8 @@
 
 import logging
 import os
-import six
 import sys
 
-from kubernetes import config
 from ops.cli.parser import SubParserConfig
 from ops.hierarchical.composition_config_generator import CompositionConfigGenerator
 
@@ -83,32 +81,16 @@ class HelmfileRunner(CompositionConfigGenerator, object):
         return dict(command=command)
 
     def setup_kube_config(self, data):
-        if 'cluster' in data and 'fqdn' in data['cluster'] and 'eks' in data['cluster']['fqdn']:
-            cluster_name = data['cluster']['fqdn']
-            aws_profile = data['account']['name']
-            region = data['region']['location']
+        if  data['helm']['global']['clusterType'] == 'eks':
+            cluster_name = data['helm']['global']['fqdn']
+            aws_profile = data['helm']['global']['aws']['name']
+            region = data['helm']['global']['region']['location']
             file_location = self.generate_eks_kube_config(
                 cluster_name, aws_profile, region)
             os.environ['KUBECONFIG'] = file_location
         else:
-            logger.info('cluster.fqdn key missing in cluster definition'
-                        '\n unable to generate EKS kubeconfig\n '
-                        'looking for system kubernetes context')
-
-            try:
-                contexts, active_context = config.list_kube_config_contexts()
-            except Exception as ex:
-                logger.error('could not find system kubeconfig context')
-                logger.error(ex)
-                sys.exit()
-
-            logger.info('current default context is:\n %s '
-                        '\n do you want to proceed with this context?',
-                        active_context)
-            answer = six.moves.input("Only 'yes' will be accepted to approve.\n Enter a value:")
-            if answer != "yes":
-                sys.exit()
-
+            logger.info('currently only eks type clusters supported')
+            sys.exit(1)
 
     def generate_eks_kube_config(self, cluster_name, aws_profile, region):
         file_location = self.get_tmp_file()

--- a/src/ops/cli/helmfile.py
+++ b/src/ops/cli/helmfile.py
@@ -89,7 +89,7 @@ class HelmfileRunner(CompositionConfigGenerator, object):
                 cluster_name, aws_profile, region)
             os.environ['KUBECONFIG'] = file_location
         else:
-            logger.info('currently only eks type clusters supported')
+            logger.warning('currently only eks type clusters supported')
             sys.exit(1)
 
     def generate_eks_kube_config(self, cluster_name, aws_profile, region):


### PR DESCRIPTION
Removed default context fallback.  

## Description
Running directly against default kubernetes configured context has proven to be dangerous.
behaviour has improve after https://github.com/adobe/ops-cli/issues/84 was closed but after internal discusions it has been decided to remove running agains default kubernetes context altogether.  

Running against non eks clusters will be added in the future by adding in ops the possibility to explicitly specify the context (https://github.com/adobe/ops-cli/issues/89).  

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
