### PR TITLE
Fix some spelling errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ usage: ops cluster_config_path run [-h] [--ask-sudo-pass] [--limit LIMIT]
 positional arguments:
   host_pattern     Limit the run to the following hosts
   shell_command    Shell command you want to run
-  extra_args       Extra ansible argumetns
+  extra_args       Extra ansible arguments
 
 optional arguments:
   -h, --help       show this help message and exit
@@ -644,12 +644,12 @@ A cluster file will only need to use a construct like the following:
 db_password: "{{'secret/campaign/generated_password'|managed_vault_secret(policy=128)}}"
 ```
 Which will translate behind the scenes in :
-- look up in vault the secrets at secret/campaign/generated_password in the default key 'value' (Adobe convention that can be overriden with the key parameter)
+- look up in vault the secrets at secret/campaign/generated_password in the default key 'value' (Adobe convention that can be overridden with the key parameter)
 - if the value there is missing, generate a new secret using the engine passgen with a policy of length 128 characters
 - return the generated value
 - if the value at that path already exist, just return that value.
 This allows us to just refer in cluster files a secret that actually exists in vault and make sure we only generate it once - if it was already created by os or any other system, we will just use what is already there.
-The reference is by means of fixed form jinja call  added to the cluster file, which ends up interpretted later during the templating phase.
+The reference is by means of fixed form jinja call  added to the cluster file, which ends up interpreted later during the templating phase.
 
 ### Amazon Secrets Manager (SSM)
 

--- a/examples/cassandra-stress/ansible/templates/cassandra_defaults.yaml
+++ b/examples/cassandra-stress/ansible/templates/cassandra_defaults.yaml
@@ -381,7 +381,7 @@ memtable_allocation_type: offheap_objects
 # to the number of cores.
 #memtable_flush_writers: 8
 
-# A fixed memory pool size in MB for for SSTable index summaries. If left
+# A fixed memory pool size in MB for SSTable index summaries. If left
 # empty, this will default to 5% of the heap size. If the memory usage of
 # all index summaries exceeds this limit, SSTables with low read rates will
 # shrink their index summaries in order to meet this limit.  However, this
@@ -577,7 +577,7 @@ auto_snapshot: true
 # tombstones seen in memory so we can return them to the coordinator, which
 # will use them to make sure other replicas also know about the deleted rows.
 # With workloads that generate a lot of tombstones, this can cause performance
-# problems and even exaust the server heap.
+# problems and even exhaust the server heap.
 # (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
 # Adjust the thresholds here if you understand the dangers and want to
 # scan more tombstones anyway.  These thresholds may also be adjusted at runtime
@@ -589,7 +589,7 @@ tombstone_failure_threshold: 100000
 # Increase if your rows are large, or if you have a very large
 # number of rows per partition.  The competing goals are these:
 #   1) a smaller granularity means more index entries are generated
-#      and looking up rows withing the partition by collation column
+#      and looking up rows within the partition by collation column
 #      is faster
 #   2) but, Cassandra will keep the collation index in memory for hot
 #      rows (as part of the key cache), so a larger granularity means

--- a/examples/cassandra-stress/ansible/templates/cassandra_defaults_12.yaml
+++ b/examples/cassandra-stress/ansible/templates/cassandra_defaults_12.yaml
@@ -637,10 +637,10 @@ request_scheduler: org.apache.cassandra.scheduler.NoScheduler
 # the request scheduling. Currently the only valid option is keyspace.
 # request_scheduler_id: keyspace
 
-# index_interval controls the sampling of entries from the primrary
+# index_interval controls the sampling of entries from the primary
 # row index in terms of space versus time.  The larger the interval,
-# the smaller and less effective the sampling will be.  In technicial
-# terms, the interval coresponds to the number of index entries that
+# the smaller and less effective the sampling will be.  In technical
+# terms, the interval corresponds to the number of index entries that
 # are skipped between taking each sample.  All the sampled entries
 # must fit in memory.  Generally, a value between 128 and 512 here
 # coupled with a large key cache size on CFs results in the best trade

--- a/examples/features/ansible-vault/README.md
+++ b/examples/features/ansible-vault/README.md
@@ -1,4 +1,4 @@
-## Minimal example to cover usage of vault with ansible playbboks
+## Minimal example to cover usage of vault with ansible playbooks
 
 ### Editing vault items
 

--- a/examples/features/inventory/README.md
+++ b/examples/features/inventory/README.md
@@ -1,4 +1,4 @@
-Assumming you have instances already running in AWS, you can use `ops` to manage them or, at the very least, you can list them.
+Assuming you have instances already running in AWS, you can use `ops` to manage them or, at the very least, you can list them.
 The tool leverages an AWS tag that needs to be present on the EC2 instances called `cluster`. 
 
 The following examples lists nodes for the defined AWS profile, that have the tag `cluster` = `mycluster1`. 

--- a/src/ops/cli/aws.py
+++ b/src/ops/cli/aws.py
@@ -11,7 +11,7 @@
 from . import get_output
 
 
-def acess_key(profile):
+def access_key(profile):
     return get_output(
         'aws configure get aws_access_key_id --profile %s' % profile)
 

--- a/src/ops/cli/packer.py
+++ b/src/ops/cli/packer.py
@@ -50,7 +50,7 @@ class PackerRunner(object):
         if config_all['packer']['clouds'] is not None:
             if 'aws' in config_all['packer']['clouds']:
                 profile_name = config_all['packer']['clouds']['aws']['boto_profile']
-                packer_variables['aws_access_key'] = aws.acess_key(
+                packer_variables['aws_access_key'] = aws.access_key(
                     profile_name)
                 packer_variables['aws_secret_key'] = aws.secret_key(
                     profile_name)

--- a/src/ops/cli/run.py
+++ b/src/ops/cli/run.py
@@ -43,7 +43,7 @@ class CommandParserConfig(SubParserConfig):
             'extra_args',
             type=str,
             nargs='*',
-            help='Extra ansible argumetns')
+            help='Extra ansible arguments')
 
     def get_help(self):
         return 'Runs a command against hosts in the cluster'

--- a/src/ops/inventory/SKMS.py
+++ b/src/ops/inventory/SKMS.py
@@ -371,7 +371,7 @@ class WebApiClient(object):
             return self.status
 
     def get_response_header(self):
-        """Returns the reponse header of the last request"""
+        """Returns the response header of the last request"""
         return self.response_header
 
     def get_response_string(self):

--- a/src/ops/inventory/generator.py
+++ b/src/ops/inventory/generator.py
@@ -78,7 +78,7 @@ class CachedInventoryGenerator(object):
             default_cache_dir, self.cluster_config['inventory']))
 
     def clear_cache(self):
-        # Note: This function is not used when --refesh-cache is passed
+        # Note: This function is not used when --refresh-cache is passed
         cache = self._get_cache()
         if cache:
             display.display(

--- a/src/ops/inventory/plugin/skms.py
+++ b/src/ops/inventory/plugin/skms.py
@@ -170,7 +170,7 @@ def skms(args):
             dictionary_of_hosts[info['cluster']]['hosts'].append(
                 info['name'].encode('utf-8'))
 
-        # tie some extra information to hostname in the meta varaiables
+        # tie some extra information to hostname in the meta variables
         dictionary_of_hosts['_meta']['hostvars'][info['name'].encode('utf-8')] = {
             'ec2_id': info['device_id'].encode('utf-8'),
             'ansible_ssh_host': info['primary_ip_address'].encode('utf-8'),

--- a/src/ops/simplevault.py
+++ b/src/ops/simplevault.py
@@ -225,7 +225,7 @@ class ManagedVaultSecret(object):
             if self.actual_policy['engine'] == 'passgen':
                 try:
                     import passgen
-                except ImportErrori as e:
+                except ImportError as e:
                     display(
                         'MANAGED-SECRET: You need passgen python module '
                         'in order to use the passgen engine.'

--- a/src/ops/terraform/terraform_cmd_generator.py
+++ b/src/ops/terraform/terraform_cmd_generator.py
@@ -341,7 +341,7 @@ class TerraformCommandGenerator(object):
         home_dir = os.environ.get('HOME')
         plan_variables['shared_credentials_file'] = '"{}/.aws/credentials"'.format(
             home_dir)
-        # plan_variables['access_key'] = '"%s"' % aws.acess_key(profile_name)
+        # plan_variables['access_key'] = '"%s"' % aws.access_key(profile_name)
         # plan_variables['secret_key'] = '"%s"' % aws.secret_key(profile_name)
 
     def get_terraform_path(self):


### PR DESCRIPTION
## Description

Fix some spelling errors. This is IMHO a purely cosmetic/non-functional change.

argumetns -> arguments (2x)
assumming -> assuming (1x)
coresponds -> corresponds (1x)
exaust -> exhaust (1x)
for for -> for (1x)
interpretted -> interpreted (1x)
overriden -> overridden (1x)
playbboks -> playbooks (1x)
primrary -> primary (1x)
refesh -> refresh (1x)
reponse -> response (1x)
technicial -> technical (1x)
varaiables -> variables (1x)
withing -> within (1x)

I've identified two other typos - but since fixing these would introduce a functional change, I *did not* touch them:

./src/ops/cli/aws.py:14 `def acess_key(profile):` (acess_key -> access_key)
./src/ops/simplevault.py:228 `except ImportErrori as e:` (ImportErrori -> ImportError)

## Related Issue

n/a

## Motivation and Context

Spelling errors are not nice...

## How Has This Been Tested?

Non-functional change, mostly affecting code comments and readme files => no tests required.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
