### PR TITLE
Fix missing ansible cli extra_vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ It can be used to add a layer of templating (using jinja2) on top of Terraform f
             * [Terraform landscape](#terraform-landscape)
          * [SSH](#ssh)
             * [SSHPass](#sshpass)
+            * [Balabit SCB](#scb)
          * [Play](#play)
          * [Run command](#run-command)
          * [Sync files](#sync-files)

--- a/src/ops/cli/ssh.py
+++ b/src/ops/cli/ssh.py
@@ -286,7 +286,7 @@ class SshRunner(object):
         if args.proxy:
             if scb_enabled:
                 proxy_port = args.local or SshConfigGenerator.generate_ssh_scb_proxy_port(
-                    self.ansible_inventory.generated_path.rstrip("/inventory"),
+                    self.ansible_inventory.generated_path.removesuffix("/inventory"),
                     args.auto_scb_port,
                     scb_proxy_port
                 )

--- a/src/ops/inventory/sshconfig.py
+++ b/src/ops/inventory/sshconfig.py
@@ -90,7 +90,7 @@ class SshConfigGenerator(object):
         ssh_config_content = ssh_config_template.format(
             scb_proxy_port=scb_proxy_port
         )
-        ssh_config_path = ssh_config_tpl_path.rstrip("_tpl")
+        ssh_config_path = ssh_config_tpl_path.removesuffix("_tpl")
         with open(ssh_config_path, 'w') as f:
             f.write(ssh_config_content)
             os.fchmod(f.fileno(), 0o644)

--- a/tests/e2e/fixture/ansible/playbooks/play_module.yaml
+++ b/tests/e2e/fixture/ansible/playbooks/play_module.yaml
@@ -1,8 +1,13 @@
 - hosts: web
   gather_facts: no
+  vars:
+    test_cmd_var: false
+    test_cmd_bool_var: True
   tasks:
     - debug: msg="{{ 'filter_this' | my_filter }}"
     - my_module:
         set_facts:
           the_module_works: yep
     - debug: var=the_module_works
+    - debug: msg="test_cmd_var = {{ test_cmd_var | bool }}"
+    - debug: msg="test_cmd_bool_var = {{ test_cmd_bool_var }}"

--- a/tests/e2e/test_playbook.py
+++ b/tests/e2e/test_playbook.py
@@ -31,19 +31,25 @@ current_dir = os.path.dirname(__file__)
 def test_loading_of_modules_and_extensions(capsys, app):
     root_dir = current_dir + '/fixture/ansible'
     container = app(['-vv', '--root-dir', root_dir, 'clusters/test.yaml', 'play',
-                       'playbooks/play_module.yaml'])
+                       'playbooks/play_module.yaml', '--', '-e', 'test_cmd_var=true',
+                       '-e', '\'{"test_cmd_bool_var": false}\''])
     command = container.run()
     code = container.execute(command, pass_trough=False)
     out, err = capsys.readouterr()
     display(out, color='gray')
     display(err, color='red')
     assert code is 0
-
     # the filter plugins work
     assert '"msg": "filtered: filter_this"' in out
 
     # custom modules are interpreted
     assert '"the_module_works": "yep"' in out
+
+    # cmd extra_vars override playbook vars
+    assert '"test_cmd_var = True"' in out
+
+    # cmd extra_vars bool var
+    assert '"test_cmd_bool_var = False"' in out
 
     # cluster is present as a variable in the command line
     assert '-e cluster=test' in command['command']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context
Ansible cli extra_vars (-e var=value) were not actually used due to some caching issues

## How Has This Been Tested?
Updated the tests with specific case which was not covered before

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
